### PR TITLE
Feat/Add-create-user-service

### DIFF
--- a/src/spreadsheet/spreadsheet.module.ts
+++ b/src/spreadsheet/spreadsheet.module.ts
@@ -7,5 +7,6 @@ import { FirebaseModule } from 'src/shared/providers/firebase/firebase.module';
   imports: [FirebaseModule],
   controllers: [SpreadsheetController],
   providers: [SpreadsheetService],
+  exports: [SpreadsheetService],
 })
 export class SpreadsheetModule {}

--- a/src/user/create-user.service.ts
+++ b/src/user/create-user.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { UserService } from './user.service';
+import { SpreadsheetService } from 'src/spreadsheet/spreadsheet.service';
+import { CreateUserDto } from './dto/create-user.dto';
+
+@Injectable()
+export class CreateUseService {
+  constructor(
+    private readonly userSvc: UserService,
+    private readonly spreadSheetSvc: SpreadsheetService,
+  ) {}
+
+  async execute(newUserDto: CreateUserDto): Promise<string> {
+    const resp = await this.userSvc.create(newUserDto);
+
+    const spreadSheetId = await this.spreadSheetSvc.createPersonalSpreadsheet({
+      ownerId: resp.id,
+      name: `${newUserDto.name}'s Personal Spreadsheet`,
+    });
+
+    await this.userSvc.setPersonalSpreadSheet(resp.id, spreadSheetId);
+
+    return resp.id;
+  }
+}

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,12 +1,12 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsString } from "class-validator";
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString } from 'class-validator';
 
 export class CreateUserDto {
-    @ApiProperty({required: true})
-    @IsString({message: 'The name of the user must be a string'})
-    name: string;
+  @ApiProperty({ required: true })
+  @IsString({ message: 'The name of the user must be a string' })
+  name: string;
 
-    @ApiProperty({required: true})
-    @IsEmail({}, {message: 'The email address must be a valid one'})
-    email: string;
+  @ApiProperty({ required: true })
+  @IsEmail({}, { message: 'The email address must be a valid one' })
+  email: string;
 }

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -2,6 +2,6 @@ import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { CreateUserDto } from './create-user.dto';
 
 export class UpdateUserDto extends PartialType(CreateUserDto) {
-    @ApiProperty({required: true})
-    sheetIds: Array<string>
+  @ApiProperty({ required: true })
+  sheetIds: Array<string>;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -7,21 +7,27 @@ import {
   Delete,
   Query,
   Put,
+  Res,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { FindAllQueryDto } from './dto/findAll-query.dto';
+import { CreateUseService } from './create-user.service';
+import { Response } from 'express';
 
 @ApiTags('users')
 @Controller('user')
 export class UserController {
-  constructor(private readonly userService: UserService) {}
+  constructor(
+    private readonly userService: UserService,
+    private readonly createUserSvc: CreateUseService,
+  ) {}
 
   @Post()
   async create(@Body() createUserDto: CreateUserDto) {
-    return await this.userService.create(createUserDto);
+    return await this.createUserSvc.execute(createUserDto);
   }
 
   @Get()
@@ -39,12 +45,24 @@ export class UserController {
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return await this.userService.update(id, updateUserDto);
+  async update(
+    @Param('id') id: string,
+    @Body() updateUserDto: UpdateUserDto,
+    @Res() res: Response,
+  ) {
+    await this.userService.update(id, updateUserDto);
+    res.status(200).json({
+      message: 'User updated successfully',
+      statusCode: 200,
+    });
   }
 
   @Delete(':id')
-  async remove(@Param('id') id: string) {
-    return await this.userService.remove(id);
+  async remove(@Param('id') id: string, @Res() res: Response) {
+    await this.userService.remove(id);
+    res.status(200).json({
+      message: 'User deleted successfully',
+      statusCode: 200,
+    });
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { FirebaseModule } from 'src/shared/providers/firebase/firebase.module';
+import { SpreadsheetService } from 'src/spreadsheet/spreadsheet.service';
+import { CreateUseService } from './create-user.service';
 
 @Module({
-  imports: [FirebaseModule],
+  imports: [FirebaseModule, SpreadsheetService],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, CreateUseService],
   exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,11 +2,11 @@ import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { FirebaseModule } from 'src/shared/providers/firebase/firebase.module';
-import { SpreadsheetService } from 'src/spreadsheet/spreadsheet.service';
 import { CreateUseService } from './create-user.service';
+import { SpreadsheetModule } from 'src/spreadsheet/spreadsheet.module';
 
 @Module({
-  imports: [FirebaseModule, SpreadsheetService],
+  imports: [FirebaseModule, SpreadsheetModule],
   controllers: [UserController],
   providers: [UserService, CreateUseService],
   exports: [UserService],

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -67,6 +67,23 @@ export class UserService {
     });
   }
 
+  async setPersonalSpreadSheet(id: string, spreadSheetId: string) {
+    const user = await this.findOne(id);
+
+    await this.firebase.SetDoc({
+      collection: 'users',
+      id,
+      payload: {
+        email: user.email,
+        name: user.name,
+        createdAt: user.createdAt,
+        updatedAt: new Date(),
+        sheetIds: [],
+        personalSpreadSheet: spreadSheetId,
+      },
+    });
+  }
+
   async remove(id: string) {
     await this.firebase.DeleteOne({
       collection: 'users',

--- a/src/user/user.types.ts
+++ b/src/user/user.types.ts
@@ -1,3 +1,5 @@
+import { firebaseTimesStampType } from 'src/shared/utils/firebase/firebase.types';
+
 export interface ICreateResp {
   id: string;
 }
@@ -7,4 +9,7 @@ export interface IUser {
   name: string;
   email: string;
   sheetIds: string[];
+  personalSpreadSheet: string;
+  createdAt?: firebaseTimesStampType;
+  updatedAt?: firebaseTimesStampType;
 }


### PR DESCRIPTION
Descrição do PR
Este PR introduz uma série de melhorias e novos recursos relacionados à gestão de usuários e planilhas pessoais. Abaixo está um resumo detalhado das mudanças:

#### Novos Recursos e Funcionalidades
Módulo de Usuário:
- Adicionadas novas propriedades ao tipo de usuário: `personalSpreadSheet`, `updatedAt` e `createdAt`.
- Implementado o serviço `CreateUserService`, que cria um novo usuário e, em seguida, gera uma planilha pessoal, vinculando o ID da planilha ao campo `personalSpreadSheet` do usuário.

Módulo de Planilhas:
- O serviço `SpreadSheetService` foi definido como exportável no `SpreadSheetModule`.
- O `SpreadSheetService` foi registrado na lista de imports e o `CreateUserService` foi configurado como provedor no módulo de usuários.

#### Correções de Bugs
- Substituição do `SpreadSheetService` pelo `SpreadSheetModule` para garantir a correta configuração e funcionamento da injeção de dependência.

#### Como Testar
- Verifique a criação de usuários utilizando o `CreateUserService` e confirme se as planilhas pessoais estão sendo criadas e vinculadas corretamente ao usuário.
- Teste o funcionamento do `SpreadSheetService` e assegure-se de que as exportações e importações estão configuradas corretamente nos módulos.

#### Notas Adicionais
Este PR reflete as contribuições mais recentes e visa aprimorar a interação entre os módulos de usuário e planilha, proporcionando uma melhor experiência ao manipular os dados de usuários e suas planilhas pessoais.